### PR TITLE
Adjust merge loop to handle no matches

### DIFF
--- a/.github/workflows/merge_daily_reports.yml
+++ b/.github/workflows/merge_daily_reports.yml
@@ -54,7 +54,8 @@ jobs:
           echo -e "# Merged Daily Reports for $YEAR-$MONTH\n\n" > "$OUTPUT_FILE"
 
           # 各ファイルに対して処理
-          for file in $(ls "$REPORT_DIR"/*.md | sort); do
+          shopt -s nullglob
+          for file in "$REPORT_DIR"/*.md; do
             # 各ファイルの最新コミットメッセージを取得
             LAST_COMMIT_MSG=$(git log -1 --pretty=%B -- "$file")
 


### PR DESCRIPTION
## Summary
- use `nullglob` to avoid errors when no MD files exist
- simplify `for` loop syntax

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68402751ed0483338df130d11fc4028d