### PR TITLE
Fix merge script commit logic

### DIFF
--- a/.github/workflows/merge_daily_reports.yml
+++ b/.github/workflows/merge_daily_reports.yml
@@ -77,7 +77,7 @@ jobs:
 
           if [ -f "$MERGED_FILE" ]; then
             git add "$MERGED_FILE"
-            git commit -m "${YEAR}年${MONTH}月の日報を結合"
+            git diff --cached --quiet || git commit -m "${YEAR}年${MONTH}月の日報を結合"
 
             # `GITHUB_TOKEN` を使って認証して push
             git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git


### PR DESCRIPTION
## Summary
- update merge workflow to commit only when diff exists

## Testing
- `yamllint -d relaxed .github/workflows/merge_daily_reports.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684027500a8c8333a180ac7fc179719d