### PR TITLE
Fix monthly report commit step

### DIFF
--- a/.github/workflows/generate_monthly_report.yml
+++ b/.github/workflows/generate_monthly_report.yml
@@ -89,5 +89,5 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
           git add "$REPORT_FILE"
-          git commit -m "${YEAR}年${MONTH}月の月報を追加"
+          git diff --cached --quiet || git commit -m "${YEAR}年${MONTH}月の月報を追加"
           git push origin main


### PR DESCRIPTION
## Summary
- avoid committing when no changes are present in generate_monthly_report workflow

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840274cd84883338c229244d12ea9f1