### PR TITLE
ワークフローに生成レポートのリンクを表示

### DIFF
--- a/.github/workflows/generate_monthly_report.yml
+++ b/.github/workflows/generate_monthly_report.yml
@@ -90,3 +90,6 @@ jobs:
           git add "$REPORT_FILE"
           git diff --cached --quiet || git commit -m "${YEAR}年${MONTH}月の月報を追加"
           git push origin main
+
+          LINK="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/main/$REPORT_FILE"
+          echo "月報のリンク: $LINK"

--- a/.github/workflows/generate_weekly_report.yml
+++ b/.github/workflows/generate_weekly_report.yml
@@ -179,3 +179,6 @@ jobs:
           git add "$FILE_PATH"
           git diff --cached --quiet || git commit -m "Add weekly report: ${SFMT_START} to ${SFMT_END}"
           git push origin main
+
+          LINK="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/main/$FILE_PATH"
+          echo "週報のリンク: $LINK"

--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,7 @@
 - `.github/workflows/generate_weekly_report.yml`
   指定週の学習内容を要約し `weekly_report/` に出力します。
 - これらのワークフローは **workflow_dispatch** で手動実行します。必要に応じて `schedule` トリガーを追加することも可能です。
+  実行後、ログに生成されたレポートへの URL が表示されます。
 - 例えば `schedule` を使う場合:
 ```yaml
 on:


### PR DESCRIPTION
## 概要
- 月報・週報生成ワークフローで、生成したレポートのURLをログに出力する処理を追加
- README にワークフロー実行後にリンクが表示される旨を追記

## テスト
- 既存のテストスクリプトは見当たらず、追加実行なし

------
https://chatgpt.com/codex/tasks/task_e_6850bc49fca8833386ecbf019737f0cd